### PR TITLE
Auth: Google OAuth login + protected routes

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../../../node_modules/.prisma/client"
 }
 
 datasource db {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { secureHeaders } from "hono/secure-headers";
 import { logger } from "./middleware/logger";
+import { auth } from "./lib/auth";
+import { authMiddleware } from "./middleware/auth";
 
 const app = new Hono();
 
@@ -16,8 +18,14 @@ app.use(
 );
 app.use("*", logger());
 
+// Auth routes (unprotected)
+app.on(["POST", "GET"], "/api/auth/**", (c) => auth.handler(c.req.raw));
+
 // Health check
 app.get("/health", (c) => c.json({ status: "ok" }));
+
+// Protected routes
+app.use("/api/*", authMiddleware());
 
 export default {
   port: 3000,

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -1,0 +1,16 @@
+import { betterAuth } from "better-auth";
+import { prismaAdapter } from "better-auth/adapters/prisma";
+import { prisma } from "./db";
+
+export const auth = betterAuth({
+  database: prismaAdapter(prisma, {
+    provider: "postgresql",
+  }),
+  socialProviders: {
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    },
+  },
+  trustedOrigins: ["http://localhost:5173"],
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,0 +1,20 @@
+import type { Context, MiddlewareHandler } from "hono";
+import { auth } from "../lib/auth";
+
+export const authMiddleware = (): MiddlewareHandler => {
+  return async (c, next) => {
+    const session = await auth.api.getSession({
+      headers: c.req.raw.headers,
+    });
+
+    if (!session) {
+      return c.json({ message: "Unauthorized" }, 401);
+    }
+
+    c.set("user", session.user);
+    c.set("session", session.session);
+    await next();
+  };
+};
+
+export const getUser = (c: Context) => c.get("user");

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,17 +8,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "antd": "^5.24.2",
     "@ant-design/icons": "^5.6.1",
     "@tanstack/react-query": "^5.67.2",
     "@tanstack/react-router": "^1.114.3",
+    "antd": "^5.24.2",
     "axios": "^1.7.9",
-    "recharts": "^2.15.1",
+    "better-auth": "^1.5.5",
     "dompurify": "^3.2.4",
-    "zod": "^3.24.2",
-    "shared": "workspace:*"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "recharts": "^2.15.1",
+    "shared": "workspace:*",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/react": "^19.0.10",

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,7 @@
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({
+  baseURL: "http://localhost:3000",
+});
+
+export const { signIn, signOut, useSession } = authClient;

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,8 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -19,28 +25,39 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/login'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/login'
+  id: '__root__' | '/' | '/login'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  LoginRoute: typeof LoginRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -53,6 +70,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  LoginRoute: LoginRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,10 +1,34 @@
-import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
+import { createRootRouteWithContext, Outlet, useNavigate, useLocation } from "@tanstack/react-router";
 import type { QueryClient } from "@tanstack/react-query";
+import { useSession } from "@/lib/auth";
+import { useEffect } from "react";
 
 interface RouterContext {
   queryClient: QueryClient;
 }
 
+const publicRoutes = ["/login"];
+
+function RootComponent() {
+  const { data: session, isPending } = useSession();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (isPending) return;
+
+    const isPublic = publicRoutes.includes(location.pathname);
+
+    if (!session && !isPublic) {
+      navigate({ to: "/login" });
+    }
+  }, [session, isPending, location.pathname, navigate]);
+
+  if (isPending) return null;
+
+  return <Outlet />;
+}
+
 export const Route = createRootRouteWithContext<RouterContext>()({
-  component: () => <Outlet />,
+  component: RootComponent,
 });

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,10 +1,24 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { Button, Typography } from "antd";
+import { signOut, useSession } from "@/lib/auth";
+
+const { Title, Text } = Typography;
+
+function HomePage() {
+  const { data: session } = useSession();
+
+  return (
+    <div style={{ padding: 24, textAlign: "center" }}>
+      <Title>SnapBite</Title>
+      <Text>Welcome, {session?.user?.name}</Text>
+      <br />
+      <Button onClick={() => signOut()} style={{ marginTop: 16 }}>
+        Sign out
+      </Button>
+    </div>
+  );
+}
 
 export const Route = createFileRoute("/")({
-  component: () => (
-    <div style={{ padding: 24, textAlign: "center" }}>
-      <h1>SnapBite</h1>
-      <p>AI-Powered Nutrition Tracker</p>
-    </div>
-  ),
+  component: HomePage,
 });

--- a/apps/web/src/routes/login.module.css
+++ b/apps/web/src/routes/login.module.css
@@ -1,0 +1,28 @@
+.container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+  padding: 16px;
+}
+
+.card {
+  width: 100%;
+  max-width: 400px;
+  text-align: center;
+}
+
+.title {
+  margin-bottom: 4px !important;
+}
+
+.subtitle {
+  display: block;
+  margin-bottom: 32px;
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.googleButton {
+  margin-top: 16px;
+}

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,0 +1,55 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Button, Card, Typography } from "antd";
+import { GoogleOutlined } from "@ant-design/icons";
+import { signIn, useSession } from "@/lib/auth";
+import { useEffect } from "react";
+import styles from "./login.module.css";
+
+const { Title, Text } = Typography;
+
+function LoginPage() {
+  const { data: session, isPending } = useSession();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (session) {
+      navigate({ to: "/" });
+    }
+  }, [session, navigate]);
+
+  const handleGoogleLogin = async () => {
+    await signIn.social({
+      provider: "google",
+      callbackURL: "/",
+    });
+  };
+
+  if (isPending) return null;
+
+  return (
+    <div className={styles.container}>
+      <Card className={styles.card}>
+        <Title level={2} className={styles.title}>
+          SnapBite
+        </Title>
+        <Text className={styles.subtitle}>
+          AI-Powered Nutrition Tracker
+        </Text>
+        <Button
+          type="primary"
+          size="large"
+          icon={<GoogleOutlined />}
+          onClick={handleGoogleLogin}
+          className={styles.googleButton}
+          block
+        >
+          Sign in with Google
+        </Button>
+      </Card>
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/login")({
+  component: LoginPage,
+});

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "@tanstack/react-router": "^1.114.3",
         "antd": "^5.24.2",
         "axios": "^1.7.9",
+        "better-auth": "^1.5.5",
         "dompurify": "^3.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary
- better-auth configured with Google OAuth on API (Hono)
- Auth middleware protects all /api/* routes
- Login page with Google sign-in button (Ant Design)
- Root route redirects unauthenticated users to /login
- Session state via better-auth/react useSession hook

Closes #3

## Test plan
- [ ] Run both dev servers, visit localhost:5173
- [ ] Verify redirect to /login when not authenticated
- [ ] Click Google sign-in, complete OAuth flow
- [ ] Verify redirect to home page showing user name
- [ ] Verify sign out works

🤖 Generated with [Claude Code](https://claude.com/claude-code)