### PR TITLE
Onboarding: profile form + Mifflin-St Jeor targets

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { secureHeaders } from "hono/secure-headers";
 import { logger } from "./middleware/logger";
 import { auth } from "./lib/auth";
 import { authMiddleware } from "./middleware/auth";
+import profileRoutes from "./routes/profile";
 
 const app = new Hono();
 
@@ -26,6 +27,9 @@ app.get("/health", (c) => c.json({ status: "ok" }));
 
 // Protected routes
 app.use("/api/*", authMiddleware());
+
+// API routes
+app.route("/api/profile", profileRoutes);
 
 export default {
   port: 3000,

--- a/apps/api/src/lib/targets.ts
+++ b/apps/api/src/lib/targets.ts
@@ -1,0 +1,47 @@
+import type { ActivityLevel, Gender, Goal } from "shared";
+
+const ACTIVITY_MULTIPLIERS: Record<string, number> = {
+  sedentary: 1.2,
+  light: 1.375,
+  moderate: 1.55,
+  active: 1.725,
+  very_active: 1.9,
+};
+
+const GOAL_ADJUSTMENTS: Record<string, number> = {
+  lose: -500,
+  maintain: 0,
+  gain: 500,
+};
+
+export function calculateTargets(profile: {
+  age: number;
+  gender: Gender;
+  weight: number; // kg
+  height: number; // cm
+  activityLevel: ActivityLevel;
+  goal: Goal;
+}) {
+  // Mifflin-St Jeor
+  let bmr: number;
+  if (profile.gender === "male") {
+    bmr = 10 * profile.weight + 6.25 * profile.height - 5 * profile.age + 5;
+  } else {
+    bmr = 10 * profile.weight + 6.25 * profile.height - 5 * profile.age - 161;
+  }
+
+  const tdee = bmr * ACTIVITY_MULTIPLIERS[profile.activityLevel];
+  const calories = Math.round(tdee + GOAL_ADJUSTMENTS[profile.goal]);
+
+  // Macro split: 30% protein, 40% carbs, 30% fat
+  const proteinCalories = calories * 0.3;
+  const carbsCalories = calories * 0.4;
+  const fatCalories = calories * 0.3;
+
+  return {
+    calorieTarget: calories,
+    proteinTarget: Math.round(proteinCalories / 4), // 4 cal/g
+    carbsTarget: Math.round(carbsCalories / 4), // 4 cal/g
+    fatTarget: Math.round(fatCalories / 9), // 9 cal/g
+  };
+}

--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -1,0 +1,92 @@
+import { Hono } from "hono";
+import { prisma } from "../lib/db";
+import { getUser } from "../middleware/auth";
+import { profileSchema } from "shared";
+import { calculateTargets } from "../lib/targets";
+
+const profile = new Hono();
+
+profile.get("/", async (c) => {
+  const user = getUser(c);
+  const data = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: {
+      age: true,
+      gender: true,
+      weight: true,
+      height: true,
+      activityLevel: true,
+      goal: true,
+      unitPreference: true,
+      calorieTarget: true,
+      proteinTarget: true,
+      carbsTarget: true,
+      fatTarget: true,
+    },
+  });
+  return c.json(data);
+});
+
+profile.post("/", async (c) => {
+  const user = getUser(c);
+  const body = await c.req.json();
+  const parsed = profileSchema.parse(body);
+
+  const targets = calculateTargets(parsed);
+
+  const data = await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      ...parsed,
+      ...targets,
+    },
+    select: {
+      age: true,
+      gender: true,
+      weight: true,
+      height: true,
+      activityLevel: true,
+      goal: true,
+      unitPreference: true,
+      calorieTarget: true,
+      proteinTarget: true,
+      carbsTarget: true,
+      fatTarget: true,
+    },
+  });
+
+  return c.json(data);
+});
+
+profile.put("/", async (c) => {
+  const user = getUser(c);
+  const body = await c.req.json();
+  const parsed = profileSchema.parse(body);
+
+  const targets = calculateTargets(parsed);
+
+  const data = await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      ...parsed,
+      ...targets,
+    },
+    select: {
+      age: true,
+      gender: true,
+      weight: true,
+      height: true,
+      activityLevel: true,
+      goal: true,
+      unitPreference: true,
+      calorieTarget: true,
+      proteinTarget: true,
+      carbsTarget: true,
+      fatTarget: true,
+    },
+  });
+
+  return c.json(data);
+});
+
+export default profile;

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,9 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 
+const OnboardingRoute = OnboardingRouteImport.update({
+  id: '/onboarding',
+  path: '/onboarding',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
@@ -26,31 +32,42 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/onboarding': typeof OnboardingRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/onboarding': typeof OnboardingRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/onboarding': typeof OnboardingRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login'
+  fullPaths: '/' | '/login' | '/onboarding'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login'
-  id: '__root__' | '/' | '/login'
+  to: '/' | '/login' | '/onboarding'
+  id: '__root__' | '/' | '/login' | '/onboarding'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
+  OnboardingRoute: typeof OnboardingRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/onboarding': {
+      id: '/onboarding'
+      path: '/onboarding'
+      fullPath: '/onboarding'
+      preLoaderRoute: typeof OnboardingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
       id: '/login'
       path: '/login'
@@ -71,6 +88,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
+  OnboardingRoute: OnboardingRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,7 +1,9 @@
 import { createRootRouteWithContext, Outlet, useNavigate, useLocation } from "@tanstack/react-router";
 import type { QueryClient } from "@tanstack/react-query";
 import { useSession } from "@/lib/auth";
+import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
+import api from "@/lib/axios";
 
 interface RouterContext {
   queryClient: QueryClient;
@@ -10,21 +12,35 @@ interface RouterContext {
 const publicRoutes = ["/login"];
 
 function RootComponent() {
-  const { data: session, isPending } = useSession();
+  const { data: session, isPending: authPending } = useSession();
   const navigate = useNavigate();
   const location = useLocation();
 
+  const { data: profile, isPending: profilePending } = useQuery({
+    queryKey: ["profile"],
+    queryFn: () => api.get("/api/profile").then((r) => r.data),
+    enabled: !!session,
+  });
+
   useEffect(() => {
-    if (isPending) return;
+    if (authPending) return;
+    if (session && profilePending) return;
 
     const isPublic = publicRoutes.includes(location.pathname);
 
     if (!session && !isPublic) {
       navigate({ to: "/login" });
+      return;
     }
-  }, [session, isPending, location.pathname, navigate]);
 
-  if (isPending) return null;
+    if (session && profile && !profile.age && location.pathname !== "/onboarding") {
+      navigate({ to: "/onboarding" });
+      return;
+    }
+  }, [session, authPending, profile, profilePending, location.pathname, navigate]);
+
+  if (authPending) return null;
+  if (session && profilePending) return null;
 
   return <Outlet />;
 }

--- a/apps/web/src/routes/onboarding.module.css
+++ b/apps/web/src/routes/onboarding.module.css
@@ -1,0 +1,23 @@
+.container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+  padding: 16px;
+}
+
+.card {
+  width: 100%;
+  max-width: 480px;
+}
+
+.subtitle {
+  display: block;
+  margin-bottom: 24px;
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.form {
+  margin-top: 16px;
+}

--- a/apps/web/src/routes/onboarding.tsx
+++ b/apps/web/src/routes/onboarding.tsx
@@ -1,0 +1,150 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+  Form,
+  Input,
+  InputNumber,
+  Select,
+  Button,
+  Card,
+  Typography,
+  Radio,
+  message,
+} from "antd";
+import api from "@/lib/axios";
+import styles from "./onboarding.module.css";
+
+const { Title, Text } = Typography;
+
+const activityOptions = [
+  { value: "sedentary", label: "Sedentary (little/no exercise)" },
+  { value: "light", label: "Light (1-3 days/week)" },
+  { value: "moderate", label: "Moderate (3-5 days/week)" },
+  { value: "active", label: "Active (6-7 days/week)" },
+  { value: "very_active", label: "Very Active (intense daily)" },
+];
+
+const goalOptions = [
+  { value: "lose", label: "Lose weight" },
+  { value: "maintain", label: "Maintain weight" },
+  { value: "gain", label: "Gain weight" },
+];
+
+function OnboardingPage() {
+  const [form] = Form.useForm();
+  const navigate = useNavigate();
+  const unitPreference = Form.useWatch("unitPreference", form);
+
+  const onFinish = async (values: Record<string, unknown>) => {
+    let weight = values.weight as number;
+    let height = values.height as number;
+
+    // Convert to metric for storage
+    if (values.unitPreference === "imperial") {
+      weight = weight * 0.453592; // lbs to kg
+      height = height * 2.54; // inches to cm
+    }
+
+    await api.post("/api/profile", {
+      age: values.age,
+      gender: values.gender,
+      weight: Math.round(weight * 10) / 10,
+      height: Math.round(height * 10) / 10,
+      activityLevel: values.activityLevel,
+      goal: values.goal,
+      unitPreference: values.unitPreference,
+    });
+
+    message.success("Profile saved!");
+    navigate({ to: "/" });
+  };
+
+  return (
+    <div className={styles.container}>
+      <Card className={styles.card}>
+        <Title level={2}>Welcome to SnapBite</Title>
+        <Text className={styles.subtitle}>
+          Set up your profile to calculate your daily targets
+        </Text>
+
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={onFinish}
+          initialValues={{ unitPreference: "metric", gender: "male" }}
+          className={styles.form}
+        >
+          <Form.Item
+            name="unitPreference"
+            label="Units"
+          >
+            <Radio.Group>
+              <Radio.Button value="metric">Metric</Radio.Button>
+              <Radio.Button value="imperial">Imperial</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+
+          <Form.Item
+            name="gender"
+            label="Gender"
+            rules={[{ required: true }]}
+          >
+            <Radio.Group>
+              <Radio.Button value="male">Male</Radio.Button>
+              <Radio.Button value="female">Female</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+
+          <Form.Item
+            name="age"
+            label="Age"
+            rules={[{ required: true, message: "Enter your age" }]}
+          >
+            <InputNumber min={1} max={150} style={{ width: "100%" }} />
+          </Form.Item>
+
+          <Form.Item
+            name="weight"
+            label={unitPreference === "imperial" ? "Weight (lbs)" : "Weight (kg)"}
+            rules={[{ required: true, message: "Enter your weight" }]}
+          >
+            <InputNumber min={1} step={0.1} style={{ width: "100%" }} />
+          </Form.Item>
+
+          <Form.Item
+            name="height"
+            label={unitPreference === "imperial" ? "Height (inches)" : "Height (cm)"}
+            rules={[{ required: true, message: "Enter your height" }]}
+          >
+            <InputNumber min={1} step={0.1} style={{ width: "100%" }} />
+          </Form.Item>
+
+          <Form.Item
+            name="activityLevel"
+            label="Activity Level"
+            rules={[{ required: true, message: "Select activity level" }]}
+          >
+            <Select options={activityOptions} />
+          </Form.Item>
+
+          <Form.Item
+            name="goal"
+            label="Goal"
+            rules={[{ required: true, message: "Select your goal" }]}
+          >
+            <Select options={goalOptions} />
+          </Form.Item>
+
+          <Form.Item>
+            <Button type="primary" htmlType="submit" size="large" block>
+              Calculate My Targets
+            </Button>
+          </Form.Item>
+        </Form>
+      </Card>
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/onboarding")({
+  component: OnboardingPage,
+});


### PR DESCRIPTION
## Summary
- API: POST/PUT/GET /api/profile routes with Zod validation
- Mifflin-St Jeor calorie calculation + 30/40/30 macro split
- Onboarding page with metric/imperial toggle, all profile fields
- Imperial input auto-converted to metric for DB storage
- Root route redirects first-time users (no profile) to /onboarding

Closes #4

## Test plan
- [ ] New user after OAuth → redirected to /onboarding
- [ ] Fill form with metric units, submit → targets calculated
- [ ] Switch to imperial, fill form → values converted correctly
- [ ] After onboarding, navigates to home
- [ ] Returning user with profile skips onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)