### PR TITLE
Free text meal logging with GPT-4o

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import { logger } from "./middleware/logger";
 import { auth } from "./lib/auth";
 import { authMiddleware } from "./middleware/auth";
 import profileRoutes from "./routes/profile";
+import mealsRoutes from "./routes/meals";
 
 const app = new Hono();
 
@@ -30,6 +31,7 @@ app.use("/api/*", authMiddleware());
 
 // API routes
 app.route("/api/profile", profileRoutes);
+app.route("/api/meals", mealsRoutes);
 
 export default {
   port: 3000,

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -1,0 +1,135 @@
+import OpenAI from "openai";
+import { zodResponseFormat } from "openai/helpers/zod";
+import { z } from "zod";
+import { prisma } from "./db";
+import { log } from "../middleware/logger";
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+const aiFoodItemSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  calories: z.number(),
+  protein: z.number(),
+  carbs: z.number(),
+  fat: z.number(),
+  estimatedGrams: z.number(),
+});
+
+const aiMealResponseSchema = z.object({
+  items: z.array(aiFoodItemSchema),
+});
+
+type AiFoodItem = z.infer<typeof aiFoodItemSchema>;
+
+const SYSTEM_PROMPT = `You are a nutrition analysis assistant. When given a description of food, return a structured breakdown of each food item with estimated nutritional data per the amount described.
+
+For each item provide:
+- name: the food name
+- description: brief description
+- calories: total kcal for the amount described
+- protein: grams of protein
+- carbs: grams of carbohydrates
+- fat: grams of fat
+- estimatedGrams: estimated weight in grams
+
+Be accurate and realistic with your estimates. If amounts are specified, use them. If not, estimate typical serving sizes.`;
+
+export async function analyzeText(text: string): Promise<AiFoodItem[]> {
+  log.info({ text }, "Analyzing text meal");
+
+  const response = await openai.beta.chat.completions.parse({
+    model: "gpt-4o",
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: text },
+    ],
+    response_format: zodResponseFormat(aiMealResponseSchema, "meal_analysis"),
+  });
+
+  const parsed = response.choices[0].message.parsed;
+  if (!parsed) throw new Error("Failed to parse AI response");
+
+  return parsed.items;
+}
+
+export async function analyzePhoto(base64Image: string): Promise<AiFoodItem[]> {
+  log.info("Analyzing photo meal");
+
+  const response = await openai.beta.chat.completions.parse({
+    model: "gpt-4o",
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Identify all foods in this image and provide nutritional breakdown for each.",
+          },
+          {
+            type: "image_url",
+            image_url: { url: `data:image/jpeg;base64,${base64Image}` },
+          },
+        ],
+      },
+    ],
+    response_format: zodResponseFormat(aiMealResponseSchema, "meal_analysis"),
+  });
+
+  const parsed = response.choices[0].message.parsed;
+  if (!parsed) throw new Error("Could not identify food in the image. Please retake the photo.");
+
+  if (parsed.items.length === 0) {
+    throw new Error("Could not identify food in the image. Please retake the photo.");
+  }
+
+  return parsed.items;
+}
+
+export async function lookupFood(name: string) {
+  // Check cache first
+  const cached = await prisma.food.findFirst({
+    where: { name: { equals: name, mode: "insensitive" } },
+  });
+
+  if (cached) {
+    log.info({ name }, "Food found in cache");
+    return cached;
+  }
+
+  log.info({ name }, "Looking up food via AI");
+
+  const lookupSchema = z.object({
+    name: z.string(),
+    description: z.string(),
+    caloriesPer100g: z.number(),
+    proteinPer100g: z.number(),
+    carbsPer100g: z.number(),
+    fatPer100g: z.number(),
+  });
+
+  const response = await openai.beta.chat.completions.parse({
+    model: "gpt-4o",
+    messages: [
+      {
+        role: "system",
+        content: "You are a nutrition database. Return accurate per-100g nutritional data for the requested food.",
+      },
+      { role: "user", content: `Nutritional data per 100g for: ${name}` },
+    ],
+    response_format: zodResponseFormat(z.object({ food: lookupSchema }), "food_lookup"),
+  });
+
+  const parsed = response.choices[0].message.parsed;
+  if (!parsed) throw new Error("Failed to look up food");
+
+  // Cache in DB
+  const food = await prisma.food.create({
+    data: parsed.food,
+  });
+
+  return food;
+}

--- a/apps/api/src/routes/meals.ts
+++ b/apps/api/src/routes/meals.ts
@@ -1,0 +1,149 @@
+import { Hono } from "hono";
+import { prisma } from "../lib/db";
+import { getUser } from "../middleware/auth";
+import { analyzeText, analyzePhoto } from "../lib/ai";
+import {
+  analyzeTextRequestSchema,
+  analyzePhotoRequestSchema,
+  analyzeFormRequestSchema,
+} from "shared";
+import { log } from "../middleware/logger";
+
+const meals = new Hono();
+
+// Analyze text and return preview (don't save yet)
+meals.post("/analyze-text", async (c) => {
+  const body = await c.req.json();
+  const { text } = analyzeTextRequestSchema.parse(body);
+
+  const items = await analyzeText(text);
+  const totals = items.reduce(
+    (acc, item) => ({
+      calories: acc.calories + item.calories,
+      protein: acc.protein + item.protein,
+      carbs: acc.carbs + item.carbs,
+      fat: acc.fat + item.fat,
+    }),
+    { calories: 0, protein: 0, carbs: 0, fat: 0 }
+  );
+
+  return c.json({ items, totals });
+});
+
+// Analyze photo and return preview
+meals.post("/analyze-photo", async (c) => {
+  const body = await c.req.json();
+  const { image } = analyzePhotoRequestSchema.parse(body);
+
+  const items = await analyzePhoto(image);
+  const totals = items.reduce(
+    (acc, item) => ({
+      calories: acc.calories + item.calories,
+      protein: acc.protein + item.protein,
+      carbs: acc.carbs + item.carbs,
+      fat: acc.fat + item.fat,
+    }),
+    { calories: 0, protein: 0, carbs: 0, fat: 0 }
+  );
+
+  return c.json({ items, totals });
+});
+
+// Analyze structured form and return preview
+meals.post("/analyze-form", async (c) => {
+  const body = await c.req.json();
+  const { items: formItems } = analyzeFormRequestSchema.parse(body);
+
+  const text = formItems.map((i) => `${i.amount}g of ${i.name}`).join(", ");
+  const items = await analyzeText(text);
+  const totals = items.reduce(
+    (acc, item) => ({
+      calories: acc.calories + item.calories,
+      protein: acc.protein + item.protein,
+      carbs: acc.carbs + item.carbs,
+      fat: acc.fat + item.fat,
+    }),
+    { calories: 0, protein: 0, carbs: 0, fat: 0 }
+  );
+
+  return c.json({ items, totals });
+});
+
+// Save confirmed meal
+meals.post("/", async (c) => {
+  const user = getUser(c);
+  const body = await c.req.json();
+  const { items, category } = body;
+
+  const meal = await prisma.meal.create({
+    data: {
+      userId: user.id,
+      category: category || null,
+      items: {
+        create: await Promise.all(
+          items.map(async (item: any) => {
+            // Find or create food in cache
+            let food = await prisma.food.findFirst({
+              where: { name: { equals: item.name, mode: "insensitive" } },
+            });
+
+            if (!food) {
+              const estimatedGrams = item.estimatedGrams || 100;
+              food = await prisma.food.create({
+                data: {
+                  name: item.name,
+                  description: item.description || null,
+                  caloriesPer100g: Math.round((item.calories / estimatedGrams) * 100),
+                  proteinPer100g: Math.round((item.protein / estimatedGrams) * 100 * 10) / 10,
+                  carbsPer100g: Math.round((item.carbs / estimatedGrams) * 100 * 10) / 10,
+                  fatPer100g: Math.round((item.fat / estimatedGrams) * 100 * 10) / 10,
+                },
+              });
+            }
+
+            return {
+              foodId: food.id,
+              quantity: item.estimatedGrams || 100,
+              calories: item.calories,
+              protein: item.protein,
+              carbs: item.carbs,
+              fat: item.fat,
+            };
+          })
+        ),
+      },
+    },
+    include: {
+      items: { include: { food: true } },
+    },
+  });
+
+  log.info({ mealId: meal.id }, "Meal saved");
+  return c.json(meal, 201);
+});
+
+// Get meals by date
+meals.get("/", async (c) => {
+  const user = getUser(c);
+  const date = c.req.query("date");
+
+  const where: any = { userId: user.id };
+
+  if (date) {
+    const start = new Date(date);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(date);
+    end.setHours(23, 59, 59, 999);
+    where.loggedAt = { gte: start, lte: end };
+  }
+
+  const mealsList = await prisma.meal.findMany({
+    where,
+    include: { items: { include: { food: true } } },
+    orderBy: { loggedAt: "desc" },
+  });
+
+  return c.json(mealsList);
+});
+
+export default meals;

--- a/apps/web/src/components/log/MealPreview.module.css
+++ b/apps/web/src/components/log/MealPreview.module.css
@@ -1,0 +1,26 @@
+.preview {
+  margin-top: 16px;
+}
+
+.totals {
+  display: flex;
+  gap: 4px;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 16px;
+  gap: 12px;
+}
+
+@media (max-width: 480px) {
+  .actions {
+    flex-direction: column;
+  }
+
+  .actions > * {
+    width: 100% !important;
+  }
+}

--- a/apps/web/src/components/log/MealPreview.tsx
+++ b/apps/web/src/components/log/MealPreview.tsx
@@ -1,0 +1,89 @@
+import { Table, Select, Button, Typography, message } from "antd";
+import { SaveOutlined } from "@ant-design/icons";
+import { useState } from "react";
+import DOMPurify from "dompurify";
+import api from "@/lib/axios";
+import type { FoodItem } from "shared";
+import styles from "./MealPreview.module.css";
+
+const { Text } = Typography;
+
+interface MealPreviewProps {
+  items: (FoodItem & { estimatedGrams?: number; description?: string })[];
+  totals: { calories: number; protein: number; carbs: number; fat: number };
+  onSaved: () => void;
+}
+
+const categoryOptions = [
+  { value: "breakfast", label: "Breakfast" },
+  { value: "lunch", label: "Lunch" },
+  { value: "dinner", label: "Dinner" },
+  { value: "snack", label: "Snack" },
+];
+
+export default function MealPreview({ items, totals, onSaved }: MealPreviewProps) {
+  const [category, setCategory] = useState<string | undefined>();
+  const [saving, setSaving] = useState(false);
+
+  const columns = [
+    {
+      title: "Food",
+      dataIndex: "name",
+      key: "name",
+      render: (name: string) => DOMPurify.sanitize(name),
+    },
+    { title: "Cal", dataIndex: "calories", key: "calories", render: (v: number) => Math.round(v) },
+    { title: "Protein", dataIndex: "protein", key: "protein", render: (v: number) => `${Math.round(v)}g` },
+    { title: "Carbs", dataIndex: "carbs", key: "carbs", render: (v: number) => `${Math.round(v)}g` },
+    { title: "Fat", dataIndex: "fat", key: "fat", render: (v: number) => `${Math.round(v)}g` },
+  ];
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await api.post("/api/meals", { items, category });
+      message.success("Meal logged!");
+      onSaved();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className={styles.preview}>
+      <Table
+        dataSource={items.map((item, i) => ({ ...item, key: i }))}
+        columns={columns}
+        pagination={false}
+        size="small"
+        footer={() => (
+          <div className={styles.totals}>
+            <Text strong>Total: </Text>
+            <Text>{Math.round(totals.calories)} cal</Text>
+            <Text> · {Math.round(totals.protein)}g P</Text>
+            <Text> · {Math.round(totals.carbs)}g C</Text>
+            <Text> · {Math.round(totals.fat)}g F</Text>
+          </div>
+        )}
+      />
+
+      <div className={styles.actions}>
+        <Select
+          placeholder="Category (optional)"
+          options={categoryOptions}
+          allowClear
+          onChange={setCategory}
+          style={{ width: 200 }}
+        />
+        <Button
+          type="primary"
+          icon={<SaveOutlined />}
+          onClick={handleSave}
+          loading={saving}
+        >
+          Save Meal
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/log/TextMealInput.tsx
+++ b/apps/web/src/components/log/TextMealInput.tsx
@@ -1,0 +1,65 @@
+import { Input, Button } from "antd";
+import { SendOutlined } from "@ant-design/icons";
+import { useState } from "react";
+import api from "@/lib/axios";
+import MealPreview from "./MealPreview";
+
+const { TextArea } = Input;
+
+interface TextMealInputProps {
+  onSaved: () => void;
+}
+
+export default function TextMealInput({ onSaved }: TextMealInputProps) {
+  const [text, setText] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any>(null);
+
+  const handleAnalyze = async () => {
+    if (!text.trim()) return;
+    setLoading(true);
+    setResult(null);
+    try {
+      const { data } = await api.post("/api/meals/analyze-text", { text });
+      setResult(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <TextArea
+        rows={3}
+        placeholder='Describe what you ate, e.g. "3 eggs, toast with butter, and orange juice"'
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onPressEnter={(e) => {
+          if (!e.shiftKey) {
+            e.preventDefault();
+            handleAnalyze();
+          }
+        }}
+      />
+      <Button
+        type="primary"
+        icon={<SendOutlined />}
+        onClick={handleAnalyze}
+        loading={loading}
+        disabled={!text.trim()}
+        style={{ marginTop: 12 }}
+        block
+      >
+        Analyze
+      </Button>
+
+      {result && (
+        <MealPreview
+          items={result.items}
+          totals={result.totals}
+          onSaved={onSaved}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as LogRouteImport } from './routes/log'
 import { Route as IndexRouteImport } from './routes/index'
 
 const OnboardingRoute = OnboardingRouteImport.update({
@@ -23,6 +24,11 @@ const LoginRoute = LoginRouteImport.update({
   path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LogRoute = LogRouteImport.update({
+  id: '/log',
+  path: '/log',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -31,30 +37,34 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/log': typeof LogRoute
   '/login': typeof LoginRoute
   '/onboarding': typeof OnboardingRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/log': typeof LogRoute
   '/login': typeof LoginRoute
   '/onboarding': typeof OnboardingRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/log': typeof LogRoute
   '/login': typeof LoginRoute
   '/onboarding': typeof OnboardingRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/onboarding'
+  fullPaths: '/' | '/log' | '/login' | '/onboarding'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/onboarding'
-  id: '__root__' | '/' | '/login' | '/onboarding'
+  to: '/' | '/log' | '/login' | '/onboarding'
+  id: '__root__' | '/' | '/log' | '/login' | '/onboarding'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  LogRoute: typeof LogRoute
   LoginRoute: typeof LoginRoute
   OnboardingRoute: typeof OnboardingRoute
 }
@@ -75,6 +85,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/log': {
+      id: '/log'
+      path: '/log'
+      fullPath: '/log'
+      preLoaderRoute: typeof LogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -87,6 +104,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  LogRoute: LogRoute,
   LoginRoute: LoginRoute,
   OnboardingRoute: OnboardingRoute,
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,5 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { Button, Typography } from "antd";
+import { PlusOutlined, LogoutOutlined } from "@ant-design/icons";
 import { signOut, useSession } from "@/lib/auth";
 
 const { Title, Text } = Typography;
@@ -12,9 +13,16 @@ function HomePage() {
       <Title>SnapBite</Title>
       <Text>Welcome, {session?.user?.name}</Text>
       <br />
-      <Button onClick={() => signOut()} style={{ marginTop: 16 }}>
-        Sign out
-      </Button>
+      <div style={{ marginTop: 24, display: "flex", gap: 12, justifyContent: "center" }}>
+        <Link to="/log">
+          <Button type="primary" icon={<PlusOutlined />} size="large">
+            Log a Meal
+          </Button>
+        </Link>
+        <Button icon={<LogoutOutlined />} onClick={() => signOut()}>
+          Sign out
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/log.module.css
+++ b/apps/web/src/routes/log.module.css
@@ -1,0 +1,14 @@
+.container {
+  min-height: 100vh;
+  background: #f5f5f5;
+  padding: 16px;
+  display: flex;
+  justify-content: center;
+}
+
+.card {
+  width: 100%;
+  max-width: 600px;
+  margin-top: 24px;
+  height: fit-content;
+}

--- a/apps/web/src/routes/log.tsx
+++ b/apps/web/src/routes/log.tsx
@@ -1,0 +1,59 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Tabs, Card, Typography } from "antd";
+import { EditOutlined, CameraOutlined, UnorderedListOutlined } from "@ant-design/icons";
+import TextMealInput from "@/components/log/TextMealInput";
+import styles from "./log.module.css";
+
+const { Title } = Typography;
+
+function LogPage() {
+  const navigate = useNavigate();
+
+  const onMealSaved = () => {
+    navigate({ to: "/" });
+  };
+
+  return (
+    <div className={styles.container}>
+      <Card className={styles.card}>
+        <Title level={3}>Log a Meal</Title>
+        <Tabs
+          defaultActiveKey="text"
+          items={[
+            {
+              key: "text",
+              label: (
+                <span>
+                  <EditOutlined /> Free Text
+                </span>
+              ),
+              children: <TextMealInput onSaved={onMealSaved} />,
+            },
+            {
+              key: "photo",
+              label: (
+                <span>
+                  <CameraOutlined /> Photo
+                </span>
+              ),
+              children: <div style={{ padding: 24, textAlign: "center", color: "#999" }}>Coming soon</div>,
+            },
+            {
+              key: "form",
+              label: (
+                <span>
+                  <UnorderedListOutlined /> Form
+                </span>
+              ),
+              children: <div style={{ padding: 24, textAlign: "center", color: "#999" }}>Coming soon</div>,
+            },
+          ]}
+        />
+      </Card>
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/log")({
+  component: LogPage,
+});


### PR DESCRIPTION
## Summary
- OpenAI GPT-4o integration with Zod structured output for meal analysis
- API: POST /api/meals/analyze-text, analyze-photo, analyze-form + POST /api/meals (save) + GET /api/meals (by date)
- /log page with text tab (photo + form tabs stubbed for #6 #7)
- MealPreview component: per-item table + totals + category selector + save
- Foods cached in DB on meal save (per-100g conversion)
- DOMPurify sanitization on AI-generated text

Closes #5

## Test plan
- [ ] Navigate to /log, enter free text meal description
- [ ] Click Analyze, verify per-item breakdown appears
- [ ] Select optional category, click Save Meal
- [ ] Verify meal saved to DB, redirects to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)