### PR TITLE
Photo + structured form meal logging

### DIFF
--- a/apps/web/src/components/log/FormMealInput.module.css
+++ b/apps/web/src/components/log/FormMealInput.module.css
@@ -1,0 +1,19 @@
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.nameInput {
+  flex: 2;
+}
+
+.amountInput {
+  flex: 1;
+}

--- a/apps/web/src/components/log/FormMealInput.tsx
+++ b/apps/web/src/components/log/FormMealInput.tsx
@@ -1,0 +1,101 @@
+import { Button, Input, InputNumber, Space } from "antd";
+import { PlusOutlined, DeleteOutlined, SendOutlined } from "@ant-design/icons";
+import { useState } from "react";
+import api from "@/lib/axios";
+import MealPreview from "./MealPreview";
+import styles from "./FormMealInput.module.css";
+
+interface FormRow {
+  name: string;
+  amount: number | null;
+}
+
+interface FormMealInputProps {
+  onSaved: () => void;
+}
+
+export default function FormMealInput({ onSaved }: FormMealInputProps) {
+  const [rows, setRows] = useState<FormRow[]>([{ name: "", amount: null }]);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any>(null);
+
+  const updateRow = (index: number, field: keyof FormRow, value: any) => {
+    const updated = [...rows];
+    updated[index] = { ...updated[index], [field]: value };
+    setRows(updated);
+  };
+
+  const addRow = () => setRows([...rows, { name: "", amount: null }]);
+
+  const removeRow = (index: number) => {
+    if (rows.length === 1) return;
+    setRows(rows.filter((_, i) => i !== index));
+  };
+
+  const isValid = rows.every((r) => r.name.trim() && r.amount && r.amount > 0);
+
+  const handleAnalyze = async () => {
+    if (!isValid) return;
+    setLoading(true);
+    setResult(null);
+    try {
+      const items = rows.map((r) => ({ name: r.name.trim(), amount: r.amount! }));
+      const { data } = await api.post("/api/meals/analyze-form", { items });
+      setResult(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className={styles.rows}>
+        {rows.map((row, i) => (
+          <div key={i} className={styles.row}>
+            <Input
+              placeholder="Food name"
+              value={row.name}
+              onChange={(e) => updateRow(i, "name", e.target.value)}
+              className={styles.nameInput}
+            />
+            <InputNumber
+              placeholder="Grams"
+              min={1}
+              value={row.amount}
+              onChange={(v) => updateRow(i, "amount", v)}
+              className={styles.amountInput}
+              addonAfter="g"
+            />
+            <Button
+              icon={<DeleteOutlined />}
+              onClick={() => removeRow(i)}
+              disabled={rows.length === 1}
+              danger
+              type="text"
+            />
+          </div>
+        ))}
+      </div>
+
+      <Button icon={<PlusOutlined />} onClick={addRow} style={{ marginTop: 8 }} block type="dashed">
+        Add Item
+      </Button>
+
+      <Button
+        type="primary"
+        icon={<SendOutlined />}
+        onClick={handleAnalyze}
+        loading={loading}
+        disabled={!isValid}
+        style={{ marginTop: 12 }}
+        block
+      >
+        Analyze
+      </Button>
+
+      {result && (
+        <MealPreview items={result.items} totals={result.totals} onSaved={onSaved} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/log/PhotoMealInput.module.css
+++ b/apps/web/src/components/log/PhotoMealInput.module.css
@@ -1,0 +1,24 @@
+.hiddenInput {
+  display: none;
+}
+
+.uploadArea {
+  padding: 24px 0;
+}
+
+.previewArea {
+  text-align: center;
+}
+
+.image {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: 8px;
+  object-fit: contain;
+}
+
+.analyzing {
+  text-align: center;
+  padding: 24px;
+  color: rgba(0, 0, 0, 0.45);
+}

--- a/apps/web/src/components/log/PhotoMealInput.tsx
+++ b/apps/web/src/components/log/PhotoMealInput.tsx
@@ -1,0 +1,106 @@
+import { Button, Upload, message } from "antd";
+import { CameraOutlined, UploadOutlined } from "@ant-design/icons";
+import { useState, useRef } from "react";
+import api from "@/lib/axios";
+import MealPreview from "./MealPreview";
+import styles from "./PhotoMealInput.module.css";
+
+interface PhotoMealInputProps {
+  onSaved: () => void;
+}
+
+export default function PhotoMealInput({ onSaved }: PhotoMealInputProps) {
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const processFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = async (e) => {
+      const dataUrl = e.target?.result as string;
+      setPreview(dataUrl);
+
+      const base64 = dataUrl.split(",")[1];
+      setLoading(true);
+      setResult(null);
+      try {
+        const { data } = await api.post("/api/meals/analyze-photo", { image: base64 });
+        setResult(data);
+      } catch (err: any) {
+        const msg = err.response?.data?.message || "Could not identify food. Please retake the photo.";
+        message.error(msg);
+      } finally {
+        setLoading(false);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleCapture = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) processFile(file);
+  };
+
+  const handleReset = () => {
+    setPreview(null);
+    setResult(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  return (
+    <div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        onChange={handleFileChange}
+        className={styles.hiddenInput}
+      />
+
+      {!preview ? (
+        <div className={styles.uploadArea}>
+          <Button
+            type="primary"
+            icon={<CameraOutlined />}
+            size="large"
+            onClick={handleCapture}
+            block
+          >
+            Take Photo
+          </Button>
+          <Upload
+            accept="image/*"
+            showUploadList={false}
+            beforeUpload={(file) => {
+              processFile(file);
+              return false;
+            }}
+          >
+            <Button icon={<UploadOutlined />} size="large" block style={{ marginTop: 12 }}>
+              Upload Image
+            </Button>
+          </Upload>
+        </div>
+      ) : (
+        <div className={styles.previewArea}>
+          <img src={preview} alt="Meal" className={styles.image} />
+          <Button onClick={handleReset} style={{ marginTop: 8 }}>
+            Retake
+          </Button>
+        </div>
+      )}
+
+      {loading && <div className={styles.analyzing}>Analyzing your meal...</div>}
+
+      {result && (
+        <MealPreview items={result.items} totals={result.totals} onSaved={onSaved} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/log.tsx
+++ b/apps/web/src/routes/log.tsx
@@ -2,6 +2,8 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Tabs, Card, Typography } from "antd";
 import { EditOutlined, CameraOutlined, UnorderedListOutlined } from "@ant-design/icons";
 import TextMealInput from "@/components/log/TextMealInput";
+import PhotoMealInput from "@/components/log/PhotoMealInput";
+import FormMealInput from "@/components/log/FormMealInput";
 import styles from "./log.module.css";
 
 const { Title } = Typography;
@@ -36,7 +38,7 @@ function LogPage() {
                   <CameraOutlined /> Photo
                 </span>
               ),
-              children: <div style={{ padding: 24, textAlign: "center", color: "#999" }}>Coming soon</div>,
+              children: <PhotoMealInput onSaved={onMealSaved} />,
             },
             {
               key: "form",
@@ -45,7 +47,7 @@ function LogPage() {
                   <UnorderedListOutlined /> Form
                 </span>
               ),
-              children: <div style={{ padding: 24, textAlign: "center", color: "#999" }}>Coming soon</div>,
+              children: <FormMealInput onSaved={onMealSaved} />,
             },
           ]}
         />


### PR DESCRIPTION
## Summary
- Photo tab: camera capture (mobile) or file upload, base64 sent to GPT-4o Vision
- On photo analysis failure, shows error + retake button
- Form tab: dynamic add/remove rows with food name + grams input
- Both reuse existing analyze API endpoints and MealPreview component

Closes #6
Closes #7

## Test plan
- [ ] Photo tab: upload image, verify AI identifies foods
- [ ] Photo tab: camera capture on mobile
- [ ] Photo tab: retake button resets state
- [ ] Form tab: add/remove rows, enter name + grams
- [ ] Form tab: analyze, verify preview, save meal

🤖 Generated with [Claude Code](https://claude.com/claude-code)