### PR TITLE
Dashboard: daily progress + diary

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import { auth } from "./lib/auth";
 import { authMiddleware } from "./middleware/auth";
 import profileRoutes from "./routes/profile";
 import mealsRoutes from "./routes/meals";
+import statsRoutes from "./routes/stats";
 
 const app = new Hono();
 
@@ -32,6 +33,7 @@ app.use("/api/*", authMiddleware());
 // API routes
 app.route("/api/profile", profileRoutes);
 app.route("/api/meals", mealsRoutes);
+app.route("/api/stats", statsRoutes);
 
 export default {
   port: 3000,

--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -1,0 +1,111 @@
+import { Hono } from "hono";
+import { prisma } from "../lib/db";
+import { getUser } from "../middleware/auth";
+
+const stats = new Hono();
+
+// Daily stats: totals + targets for a given date
+stats.get("/daily", async (c) => {
+  const user = getUser(c);
+  const dateParam = c.req.query("date") || new Date().toISOString().split("T")[0];
+
+  const start = new Date(dateParam);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(dateParam);
+  end.setHours(23, 59, 59, 999);
+
+  const meals = await prisma.meal.findMany({
+    where: { userId: user.id, loggedAt: { gte: start, lte: end } },
+    include: { items: true },
+  });
+
+  const totals = meals.reduce(
+    (acc, meal) => {
+      meal.items.forEach((item) => {
+        acc.calories += item.calories;
+        acc.protein += item.protein;
+        acc.carbs += item.carbs;
+        acc.fat += item.fat;
+      });
+      return acc;
+    },
+    { calories: 0, protein: 0, carbs: 0, fat: 0 }
+  );
+
+  const profile = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: {
+      calorieTarget: true,
+      proteinTarget: true,
+      carbsTarget: true,
+      fatTarget: true,
+    },
+  });
+
+  return c.json({
+    date: dateParam,
+    totals: {
+      calories: Math.round(totals.calories),
+      protein: Math.round(totals.protein),
+      carbs: Math.round(totals.carbs),
+      fat: Math.round(totals.fat),
+    },
+    targets: {
+      calories: profile?.calorieTarget || 0,
+      protein: profile?.proteinTarget || 0,
+      carbs: profile?.carbsTarget || 0,
+      fat: profile?.fatTarget || 0,
+    },
+  });
+});
+
+// Trends: daily totals for a date range
+stats.get("/trends", async (c) => {
+  const user = getUser(c);
+  const range = c.req.query("range") || "week";
+  const days = range === "month" ? 30 : 7;
+
+  const end = new Date();
+  end.setHours(23, 59, 59, 999);
+  const start = new Date();
+  start.setDate(start.getDate() - days + 1);
+  start.setHours(0, 0, 0, 0);
+
+  const meals = await prisma.meal.findMany({
+    where: { userId: user.id, loggedAt: { gte: start, lte: end } },
+    include: { items: true },
+  });
+
+  // Group by date
+  const byDate: Record<string, { calories: number; protein: number; carbs: number; fat: number }> = {};
+
+  for (let d = 0; d < days; d++) {
+    const date = new Date(start);
+    date.setDate(date.getDate() + d);
+    byDate[date.toISOString().split("T")[0]] = { calories: 0, protein: 0, carbs: 0, fat: 0 };
+  }
+
+  meals.forEach((meal) => {
+    const key = meal.loggedAt.toISOString().split("T")[0];
+    if (byDate[key]) {
+      meal.items.forEach((item) => {
+        byDate[key].calories += item.calories;
+        byDate[key].protein += item.protein;
+        byDate[key].carbs += item.carbs;
+        byDate[key].fat += item.fat;
+      });
+    }
+  });
+
+  const data = Object.entries(byDate).map(([date, totals]) => ({
+    date,
+    calories: Math.round(totals.calories),
+    protein: Math.round(totals.protein),
+    carbs: Math.round(totals.carbs),
+    fat: Math.round(totals.fat),
+  }));
+
+  return c.json(data);
+});
+
+export default stats;

--- a/apps/web/src/components/dashboard/DailyProgress.module.css
+++ b/apps/web/src/components/dashboard/DailyProgress.module.css
@@ -1,0 +1,23 @@
+.container {
+  text-align: center;
+}
+
+.calorieSection {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 24px;
+}
+
+.macros {
+  margin-top: 8px;
+}
+
+.macroBar {
+  text-align: left;
+}
+
+.macroLabel {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}

--- a/apps/web/src/components/dashboard/DailyProgress.tsx
+++ b/apps/web/src/components/dashboard/DailyProgress.tsx
@@ -1,0 +1,56 @@
+import { Progress, Typography, Row, Col } from "antd";
+import styles from "./DailyProgress.module.css";
+
+const { Text, Title } = Typography;
+
+interface DailyProgressProps {
+  totals: { calories: number; protein: number; carbs: number; fat: number };
+  targets: { calories: number; protein: number; carbs: number; fat: number };
+}
+
+function MacroBar({ label, current, target, color }: { label: string; current: number; target: number; color: string }) {
+  const percent = target > 0 ? Math.min((current / target) * 100, 100) : 0;
+  return (
+    <div className={styles.macroBar}>
+      <div className={styles.macroLabel}>
+        <Text strong>{label}</Text>
+        <Text type="secondary">{current}g / {target}g</Text>
+      </div>
+      <Progress percent={Math.round(percent)} strokeColor={color} size="small" />
+    </div>
+  );
+}
+
+export default function DailyProgress({ totals, targets }: DailyProgressProps) {
+  const caloriePercent = targets.calories > 0 ? Math.min((totals.calories / targets.calories) * 100, 100) : 0;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.calorieSection}>
+        <Progress
+          type="circle"
+          percent={Math.round(caloriePercent)}
+          format={() => (
+            <div>
+              <Title level={3} style={{ margin: 0 }}>{totals.calories}</Title>
+              <Text type="secondary">/ {targets.calories} cal</Text>
+            </div>
+          )}
+          size={160}
+          strokeColor={caloriePercent > 100 ? "#ff4d4f" : "#1890ff"}
+        />
+      </div>
+      <Row gutter={16} className={styles.macros}>
+        <Col span={8}>
+          <MacroBar label="Protein" current={totals.protein} target={targets.protein} color="#52c41a" />
+        </Col>
+        <Col span={8}>
+          <MacroBar label="Carbs" current={totals.carbs} target={targets.carbs} color="#faad14" />
+        </Col>
+        <Col span={8}>
+          <MacroBar label="Fat" current={totals.fat} target={targets.fat} color="#eb2f96" />
+        </Col>
+      </Row>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/Diary.module.css
+++ b/apps/web/src/components/dashboard/Diary.module.css
@@ -1,0 +1,23 @@
+.mealItem {
+  flex-direction: column !important;
+  align-items: stretch !important;
+}
+
+.mealHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.foodItem {
+  display: flex;
+  justify-content: space-between;
+  padding-left: 8px;
+}

--- a/apps/web/src/components/dashboard/Diary.tsx
+++ b/apps/web/src/components/dashboard/Diary.tsx
@@ -1,0 +1,71 @@
+import { List, Tag, Typography, Empty } from "antd";
+import DOMPurify from "dompurify";
+import styles from "./Diary.module.css";
+
+const { Text } = Typography;
+
+interface MealItem {
+  id: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  quantity: number;
+  food: { name: string };
+}
+
+interface Meal {
+  id: string;
+  category: string | null;
+  loggedAt: string;
+  items: MealItem[];
+}
+
+interface DiaryProps {
+  meals: Meal[];
+}
+
+const categoryColors: Record<string, string> = {
+  breakfast: "orange",
+  lunch: "blue",
+  dinner: "purple",
+  snack: "green",
+};
+
+export default function Diary({ meals }: DiaryProps) {
+  if (meals.length === 0) {
+    return <Empty description="No meals logged" />;
+  }
+
+  return (
+    <List
+      dataSource={meals}
+      renderItem={(meal) => {
+        const totalCal = meal.items.reduce((s, i) => s + i.calories, 0);
+        return (
+          <List.Item className={styles.mealItem}>
+            <div className={styles.mealHeader}>
+              <div>
+                {meal.category && (
+                  <Tag color={categoryColors[meal.category]}>{meal.category}</Tag>
+                )}
+                <Text type="secondary">
+                  {new Date(meal.loggedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                </Text>
+              </div>
+              <Text strong>{Math.round(totalCal)} cal</Text>
+            </div>
+            <div className={styles.items}>
+              {meal.items.map((item) => (
+                <div key={item.id} className={styles.foodItem}>
+                  <Text>{DOMPurify.sanitize(item.food.name)}</Text>
+                  <Text type="secondary">{Math.round(item.calories)} cal</Text>
+                </div>
+              ))}
+            </div>
+          </List.Item>
+        );
+      }}
+    />
+  );
+}

--- a/apps/web/src/routes/index.module.css
+++ b/apps/web/src/routes/index.module.css
@@ -1,0 +1,32 @@
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 16px;
+  min-height: 100vh;
+  background: #f5f5f5;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.headerActions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.dateNav {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.section {
+  margin-bottom: 16px;
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,32 +1,73 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Button, Typography } from "antd";
-import { PlusOutlined, LogoutOutlined } from "@ant-design/icons";
-import { signOut, useSession } from "@/lib/auth";
+import { Button, Card, Typography, DatePicker } from "antd";
+import { PlusOutlined, LeftOutlined, RightOutlined, SettingOutlined } from "@ant-design/icons";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import dayjs from "dayjs";
+import api from "@/lib/axios";
+import { signOut } from "@/lib/auth";
+import DailyProgress from "@/components/dashboard/DailyProgress";
+import Diary from "@/components/dashboard/Diary";
+import styles from "./index.module.css";
 
-const { Title, Text } = Typography;
+const { Title } = Typography;
 
-function HomePage() {
-  const { data: session } = useSession();
+function DashboardPage() {
+  const [date, setDate] = useState(dayjs());
+  const dateStr = date.format("YYYY-MM-DD");
+
+  const { data: stats } = useQuery({
+    queryKey: ["stats", "daily", dateStr],
+    queryFn: () => api.get(`/api/stats/daily?date=${dateStr}`).then((r) => r.data),
+  });
+
+  const { data: meals } = useQuery({
+    queryKey: ["meals", dateStr],
+    queryFn: () => api.get(`/api/meals?date=${dateStr}`).then((r) => r.data),
+  });
+
+  const goDay = (offset: number) => setDate(date.add(offset, "day"));
+  const isToday = date.isSame(dayjs(), "day");
 
   return (
-    <div style={{ padding: 24, textAlign: "center" }}>
-      <Title>SnapBite</Title>
-      <Text>Welcome, {session?.user?.name}</Text>
-      <br />
-      <div style={{ marginTop: 24, display: "flex", gap: 12, justifyContent: "center" }}>
-        <Link to="/log">
-          <Button type="primary" icon={<PlusOutlined />} size="large">
-            Log a Meal
-          </Button>
-        </Link>
-        <Button icon={<LogoutOutlined />} onClick={() => signOut()}>
-          Sign out
-        </Button>
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <Title level={3} style={{ margin: 0 }}>SnapBite</Title>
+        <div className={styles.headerActions}>
+          <Link to="/log">
+            <Button type="primary" icon={<PlusOutlined />}>Log Meal</Button>
+          </Link>
+          <Link to="/settings">
+            <Button icon={<SettingOutlined />} />
+          </Link>
+          <Button size="small" onClick={() => signOut()}>Sign out</Button>
+        </div>
       </div>
+
+      <div className={styles.dateNav}>
+        <Button icon={<LeftOutlined />} onClick={() => goDay(-1)} type="text" />
+        <DatePicker
+          value={date}
+          onChange={(d) => d && setDate(d)}
+          allowClear={false}
+          format="ddd, MMM D"
+        />
+        <Button icon={<RightOutlined />} onClick={() => goDay(1)} type="text" disabled={isToday} />
+      </div>
+
+      {stats && (
+        <Card className={styles.section}>
+          <DailyProgress totals={stats.totals} targets={stats.targets} />
+        </Card>
+      )}
+
+      <Card title="Meals" className={styles.section}>
+        <Diary meals={meals || []} />
+      </Card>
     </div>
   );
 }
 
 export const Route = createFileRoute("/")({
-  component: HomePage,
+  component: DashboardPage,
 });


### PR DESCRIPTION
## Summary
- Stats API: GET /api/stats/daily (totals + targets for date), GET /api/stats/trends (weekly/monthly)
- Dashboard replaces home page: circular calorie progress, macro progress bars
- Diary section showing meals grouped by time with category tags
- Day browser (prev/next buttons + date picker) to view past days

Closes #8

## Test plan
- [ ] Dashboard shows daily calorie circle + macro bars
- [ ] Progress reflects logged meals
- [ ] Day navigation works (prev/next, date picker)
- [ ] Diary lists meals with food items and calories
- [ ] Empty state when no meals

🤖 Generated with [Claude Code](https://claude.com/claude-code)