### PR TITLE
feat: trend charts + edit/delete meals (#9, #10)

### DIFF
--- a/apps/api/src/routes/meals.ts
+++ b/apps/api/src/routes/meals.ts
@@ -122,6 +122,78 @@ meals.post("/", async (c) => {
   return c.json(meal, 201);
 });
 
+// Update meal
+meals.put("/:id", async (c) => {
+  const user = getUser(c);
+  const mealId = c.req.param("id");
+  const { items } = await c.req.json();
+
+  // Verify ownership
+  const existing = await prisma.meal.findFirst({
+    where: { id: mealId, userId: user.id },
+  });
+  if (!existing) return c.json({ error: "Not found" }, 404);
+
+  // Delete old items and recreate
+  await prisma.mealItem.deleteMany({ where: { mealId } });
+
+  const meal = await prisma.meal.update({
+    where: { id: mealId },
+    data: {
+      items: {
+        create: await Promise.all(
+          items.map(async (item: any) => {
+            let food = await prisma.food.findFirst({
+              where: { name: { equals: item.name, mode: "insensitive" } },
+            });
+            if (!food) {
+              const qty = item.quantity || 100;
+              food = await prisma.food.create({
+                data: {
+                  name: item.name,
+                  caloriesPer100g: Math.round((item.calories / qty) * 100),
+                  proteinPer100g: Math.round((item.protein / qty) * 100 * 10) / 10,
+                  carbsPer100g: Math.round((item.carbs / qty) * 100 * 10) / 10,
+                  fatPer100g: Math.round((item.fat / qty) * 100 * 10) / 10,
+                },
+              });
+            }
+            return {
+              foodId: food.id,
+              quantity: item.quantity || 100,
+              calories: item.calories,
+              protein: item.protein,
+              carbs: item.carbs,
+              fat: item.fat,
+            };
+          })
+        ),
+      },
+    },
+    include: { items: { include: { food: true } } },
+  });
+
+  log.info({ mealId }, "Meal updated");
+  return c.json(meal);
+});
+
+// Delete meal
+meals.delete("/:id", async (c) => {
+  const user = getUser(c);
+  const mealId = c.req.param("id");
+
+  const existing = await prisma.meal.findFirst({
+    where: { id: mealId, userId: user.id },
+  });
+  if (!existing) return c.json({ error: "Not found" }, 404);
+
+  await prisma.mealItem.deleteMany({ where: { mealId } });
+  await prisma.meal.delete({ where: { id: mealId } });
+
+  log.info({ mealId }, "Meal deleted");
+  return c.json({ success: true });
+});
+
 // Get meals by date
 meals.get("/", async (c) => {
   const user = getUser(c);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,10 +14,11 @@
     "antd": "^5.24.2",
     "axios": "^1.7.9",
     "better-auth": "^1.5.5",
+    "dayjs": "^1.11.20",
     "dompurify": "^3.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "recharts": "^2.15.1",
+    "recharts": "^3.8.0",
     "shared": "workspace:*",
     "zod": "^3.24.2"
   },

--- a/apps/web/src/components/dashboard/Diary.module.css
+++ b/apps/web/src/components/dashboard/Diary.module.css
@@ -16,6 +16,12 @@
   gap: 4px;
 }
 
+.mealActions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .foodItem {
   display: flex;
   justify-content: space-between;

--- a/apps/web/src/components/dashboard/Diary.tsx
+++ b/apps/web/src/components/dashboard/Diary.tsx
@@ -1,5 +1,10 @@
-import { List, Tag, Typography, Empty } from "antd";
+import { useState } from "react";
+import { List, Tag, Typography, Empty, Button, Popconfirm, message } from "antd";
+import { EditOutlined, DeleteOutlined } from "@ant-design/icons";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import DOMPurify from "dompurify";
+import api from "@/lib/axios";
+import EditMealModal from "./EditMealModal";
 import styles from "./Diary.module.css";
 
 const { Text } = Typography;
@@ -23,6 +28,7 @@ interface Meal {
 
 interface DiaryProps {
   meals: Meal[];
+  dateStr: string;
 }
 
 const categoryColors: Record<string, string> = {
@@ -32,40 +38,77 @@ const categoryColors: Record<string, string> = {
   snack: "green",
 };
 
-export default function Diary({ meals }: DiaryProps) {
+export default function Diary({ meals, dateStr }: DiaryProps) {
+  const [editingMeal, setEditingMeal] = useState<Meal | null>(null);
+  const queryClient = useQueryClient();
+
+  const deleteMutation = useMutation({
+    mutationFn: (mealId: string) => api.delete(`/api/meals/${mealId}`),
+    onSuccess: () => {
+      message.success("Meal deleted");
+      queryClient.invalidateQueries({ queryKey: ["meals", dateStr] });
+      queryClient.invalidateQueries({ queryKey: ["stats", "daily", dateStr] });
+      queryClient.invalidateQueries({ queryKey: ["stats", "trends"] });
+    },
+  });
+
   if (meals.length === 0) {
     return <Empty description="No meals logged" />;
   }
 
   return (
-    <List
-      dataSource={meals}
-      renderItem={(meal) => {
-        const totalCal = meal.items.reduce((s, i) => s + i.calories, 0);
-        return (
-          <List.Item className={styles.mealItem}>
-            <div className={styles.mealHeader}>
-              <div>
-                {meal.category && (
-                  <Tag color={categoryColors[meal.category]}>{meal.category}</Tag>
-                )}
-                <Text type="secondary">
-                  {new Date(meal.loggedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-                </Text>
-              </div>
-              <Text strong>{Math.round(totalCal)} cal</Text>
-            </div>
-            <div className={styles.items}>
-              {meal.items.map((item) => (
-                <div key={item.id} className={styles.foodItem}>
-                  <Text>{DOMPurify.sanitize(item.food.name)}</Text>
-                  <Text type="secondary">{Math.round(item.calories)} cal</Text>
+    <>
+      <List
+        dataSource={meals}
+        renderItem={(meal) => {
+          const totalCal = meal.items.reduce((s, i) => s + i.calories, 0);
+          return (
+            <List.Item className={styles.mealItem}>
+              <div className={styles.mealHeader}>
+                <div>
+                  {meal.category && (
+                    <Tag color={categoryColors[meal.category]}>{meal.category}</Tag>
+                  )}
+                  <Text type="secondary">
+                    {new Date(meal.loggedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                  </Text>
                 </div>
-              ))}
-            </div>
-          </List.Item>
-        );
-      }}
-    />
+                <div className={styles.mealActions}>
+                  <Text strong>{Math.round(totalCal)} cal</Text>
+                  <Button
+                    type="text"
+                    size="small"
+                    icon={<EditOutlined />}
+                    onClick={() => setEditingMeal(meal)}
+                  />
+                  <Popconfirm
+                    title="Delete this meal?"
+                    onConfirm={() => deleteMutation.mutate(meal.id)}
+                    okText="Delete"
+                    cancelText="Cancel"
+                  >
+                    <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+                  </Popconfirm>
+                </div>
+              </div>
+              <div className={styles.items}>
+                {meal.items.map((item) => (
+                  <div key={item.id} className={styles.foodItem}>
+                    <Text>{DOMPurify.sanitize(item.food.name)}</Text>
+                    <Text type="secondary">{Math.round(item.calories)} cal</Text>
+                  </div>
+                ))}
+              </div>
+            </List.Item>
+          );
+        }}
+      />
+      <EditMealModal
+        meal={editingMeal}
+        open={!!editingMeal}
+        onClose={() => setEditingMeal(null)}
+        dateStr={dateStr}
+      />
+    </>
   );
 }

--- a/apps/web/src/components/dashboard/EditMealModal.module.css
+++ b/apps/web/src/components/dashboard/EditMealModal.module.css
@@ -1,0 +1,14 @@
+.row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+  align-items: center;
+}
+
+.row .name {
+  flex: 2;
+}
+
+.row .number {
+  flex: 1;
+}

--- a/apps/web/src/components/dashboard/EditMealModal.tsx
+++ b/apps/web/src/components/dashboard/EditMealModal.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from "react";
+import { Modal, Input, InputNumber, Typography, message } from "antd";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import api from "@/lib/axios";
+import styles from "./EditMealModal.module.css";
+
+const { Text } = Typography;
+
+interface MealItem {
+  id: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  quantity: number;
+  food: { name: string };
+}
+
+interface Meal {
+  id: string;
+  category: string | null;
+  loggedAt: string;
+  items: MealItem[];
+}
+
+interface EditMealModalProps {
+  meal: Meal | null;
+  open: boolean;
+  onClose: () => void;
+  dateStr: string;
+}
+
+interface EditableItem {
+  id: string;
+  name: string;
+  quantity: number;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+}
+
+export default function EditMealModal({ meal, open, onClose, dateStr }: EditMealModalProps) {
+  const [items, setItems] = useState<EditableItem[]>([]);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (meal) {
+      setItems(
+        meal.items.map((i) => ({
+          id: i.id,
+          name: i.food.name,
+          quantity: i.quantity,
+          calories: i.calories,
+          protein: i.protein,
+          carbs: i.carbs,
+          fat: i.fat,
+        }))
+      );
+    }
+  }, [meal]);
+
+  const mutation = useMutation({
+    mutationFn: (data: { items: EditableItem[] }) =>
+      api.put(`/api/meals/${meal?.id}`, data),
+    onSuccess: () => {
+      message.success("Meal updated");
+      queryClient.invalidateQueries({ queryKey: ["meals", dateStr] });
+      queryClient.invalidateQueries({ queryKey: ["stats", "daily", dateStr] });
+      queryClient.invalidateQueries({ queryKey: ["stats", "trends"] });
+      onClose();
+    },
+  });
+
+  const updateItem = (idx: number, field: keyof EditableItem, value: any) => {
+    setItems((prev) => prev.map((item, i) => (i === idx ? { ...item, [field]: value } : item)));
+  };
+
+  return (
+    <Modal
+      title="Edit Meal"
+      open={open}
+      onOk={() => mutation.mutate({ items })}
+      onCancel={onClose}
+      confirmLoading={mutation.isPending}
+      width={600}
+    >
+      <div>
+        <div className={styles.row} style={{ marginBottom: 4 }}>
+          <Text strong className={styles.name}>Food</Text>
+          <Text strong className={styles.number}>Qty (g)</Text>
+          <Text strong className={styles.number}>Cal</Text>
+          <Text strong className={styles.number}>P (g)</Text>
+          <Text strong className={styles.number}>C (g)</Text>
+          <Text strong className={styles.number}>F (g)</Text>
+        </div>
+        {items.map((item, idx) => (
+          <div key={item.id} className={styles.row}>
+            <Input
+              className={styles.name}
+              value={item.name}
+              onChange={(e) => updateItem(idx, "name", e.target.value)}
+            />
+            <InputNumber
+              className={styles.number}
+              value={item.quantity}
+              min={1}
+              onChange={(v) => updateItem(idx, "quantity", v || 1)}
+            />
+            <InputNumber
+              className={styles.number}
+              value={item.calories}
+              min={0}
+              onChange={(v) => updateItem(idx, "calories", v || 0)}
+            />
+            <InputNumber
+              className={styles.number}
+              value={item.protein}
+              min={0}
+              step={0.1}
+              onChange={(v) => updateItem(idx, "protein", v || 0)}
+            />
+            <InputNumber
+              className={styles.number}
+              value={item.carbs}
+              min={0}
+              step={0.1}
+              onChange={(v) => updateItem(idx, "carbs", v || 0)}
+            />
+            <InputNumber
+              className={styles.number}
+              value={item.fat}
+              min={0}
+              step={0.1}
+              onChange={(v) => updateItem(idx, "fat", v || 0)}
+            />
+          </div>
+        ))}
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/dashboard/TrendCharts.module.css
+++ b/apps/web/src/components/dashboard/TrendCharts.module.css
@@ -1,0 +1,9 @@
+.container {
+  margin-top: 8px;
+}
+
+.toggle {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 16px;
+}

--- a/apps/web/src/components/dashboard/TrendCharts.tsx
+++ b/apps/web/src/components/dashboard/TrendCharts.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Segmented, Empty, Spin } from "antd";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+import api from "@/lib/axios";
+import styles from "./TrendCharts.module.css";
+
+interface TrendPoint {
+  date: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+}
+
+export default function TrendCharts() {
+  const [range, setRange] = useState<"week" | "month">("week");
+
+  const { data, isLoading } = useQuery<TrendPoint[]>({
+    queryKey: ["stats", "trends", range],
+    queryFn: () =>
+      api.get(`/api/stats/trends?range=${range}`).then((r) => r.data),
+  });
+
+  const formatted = (data || []).map((d) => ({
+    ...d,
+    label: new Date(d.date).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    }),
+  }));
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.toggle}>
+        <Segmented
+          options={[
+            { label: "Week", value: "week" },
+            { label: "Month", value: "month" },
+          ]}
+          value={range}
+          onChange={(v) => setRange(v as "week" | "month")}
+        />
+      </div>
+
+      {isLoading ? (
+        <Spin style={{ display: "block", textAlign: "center" }} />
+      ) : formatted.length === 0 ? (
+        <Empty description="No data" />
+      ) : (
+        <ResponsiveContainer width="100%" height={250}>
+          <LineChart data={formatted}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 12 }}
+              interval={range === "month" ? 4 : 0}
+            />
+            <YAxis tick={{ fontSize: 12 }} />
+            <Tooltip />
+            <Line
+              type="monotone"
+              dataKey="calories"
+              stroke="#1890ff"
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              name="Calories"
+            />
+            <Line
+              type="monotone"
+              dataKey="protein"
+              stroke="#52c41a"
+              strokeWidth={1}
+              dot={false}
+              name="Protein (g)"
+            />
+            <Line
+              type="monotone"
+              dataKey="carbs"
+              stroke="#faad14"
+              strokeWidth={1}
+              dot={false}
+              name="Carbs (g)"
+            />
+            <Line
+              type="monotone"
+              dataKey="fat"
+              stroke="#eb2f96"
+              strokeWidth={1}
+              dot={false}
+              name="Fat (g)"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -8,6 +8,7 @@ import api from "@/lib/axios";
 import { signOut } from "@/lib/auth";
 import DailyProgress from "@/components/dashboard/DailyProgress";
 import Diary from "@/components/dashboard/Diary";
+import TrendCharts from "@/components/dashboard/TrendCharts";
 import styles from "./index.module.css";
 
 const { Title } = Typography;
@@ -62,7 +63,11 @@ function DashboardPage() {
       )}
 
       <Card title="Meals" className={styles.section}>
-        <Diary meals={meals || []} />
+        <Diary meals={meals || []} dateStr={dateStr} />
+      </Card>
+
+      <Card title="Trends" className={styles.section}>
+        <TrendCharts />
       </Card>
     </div>
   );

--- a/bun.lock
+++ b/bun.lock
@@ -35,10 +35,11 @@
         "antd": "^5.24.2",
         "axios": "^1.7.9",
         "better-auth": "^1.5.5",
+        "dayjs": "^1.11.20",
         "dompurify": "^3.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "recharts": "^2.15.1",
+        "recharts": "^3.8.0",
         "shared": "workspace:*",
         "zod": "^3.24.2",
       },
@@ -246,6 +247,8 @@
 
     "@rc-component/trigger": ["@rc-component/trigger@2.3.1", "", { "dependencies": { "@babel/runtime": "^7.23.2", "@rc-component/portal": "^1.1.0", "classnames": "^2.3.2", "rc-motion": "^2.0.0", "rc-resize-observer": "^1.3.1", "rc-util": "^5.44.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-ORENF39PeXTzM+gQEshuk460Z8N4+6DkjpxlpE7Q3gYy1iBpLrx0FOJz3h62ryrJZ/3zCAUIkT1Pb/8hHWpb3A=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
@@ -299,6 +302,8 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
@@ -363,6 +368,8 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
@@ -470,8 +477,6 @@
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
-    "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
-
     "dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
@@ -488,6 +493,8 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
+
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
@@ -498,11 +505,9 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
-    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
-
-    "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
@@ -546,6 +551,8 @@
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
@@ -571,10 +578,6 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "kysely": ["kysely@0.28.14", "", {}, "sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA=="],
-
-    "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
-
-    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -606,8 +609,6 @@
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
-    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
-
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -635,8 +636,6 @@
     "prisma": ["prisma@6.4.1", "", { "dependencies": { "@prisma/engines": "6.4.1", "esbuild": ">=0.12 <1", "esbuild-register": "3.6.0" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-q2uJkgXnua/jj66mk6P9bX/zgYJFI/jn4Yp0aS6SPRrjH/n6VyOV7RDe1vHD0DX8Aanx4MvgmUPPoYnR6MJnPg=="],
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
-
-    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
@@ -720,11 +719,9 @@
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
-
-    "react-smooth": ["react-smooth@4.0.4", "", { "dependencies": { "fast-equals": "^5.0.1", "prop-types": "^15.8.1", "react-transition-group": "^4.4.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q=="],
-
-    "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -732,9 +729,13 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
-    "recharts": ["recharts@2.15.4", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw=="],
+    "recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
 
-    "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resize-observer-polyfill": ["resize-observer-polyfill@1.5.1", "", {}, "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="],
 
@@ -808,7 +809,7 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
-    "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
@@ -830,6 +831,8 @@
 
     "@better-auth/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -837,8 +840,6 @@
     "mongodb-connection-string-url/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
     "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
-
-    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 


### PR DESCRIPTION
## Summary
- Recharts trend charts (week/month toggle) with calorie + macro lines on dashboard
- PUT/DELETE `/meals/:id` API endpoints with ownership verification
- Edit meal modal with inline per-item editing (name, qty, cal, P/C/F)
- Delete meal with Popconfirm confirmation
- Dashboard stats auto-refresh on edit/delete
- Added dayjs + recharts dependencies

Closes #9, closes #10

## Test plan
- [ ] Verify trend chart renders with week/month data
- [ ] Edit a meal item and confirm stats update
- [ ] Delete a meal and confirm removal + stats refresh
- [ ] Verify chart is responsive on mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)