### PR TITLE
feat: food lookup + favorites with quick-log (#11, #12)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,7 @@ import { authMiddleware } from "./middleware/auth";
 import profileRoutes from "./routes/profile";
 import mealsRoutes from "./routes/meals";
 import statsRoutes from "./routes/stats";
+import foodsRoutes from "./routes/foods";
 
 const app = new Hono();
 
@@ -34,6 +35,7 @@ app.use("/api/*", authMiddleware());
 app.route("/api/profile", profileRoutes);
 app.route("/api/meals", mealsRoutes);
 app.route("/api/stats", statsRoutes);
+app.route("/api/foods", foodsRoutes);
 
 export default {
   port: 3000,

--- a/apps/api/src/routes/foods.ts
+++ b/apps/api/src/routes/foods.ts
@@ -1,0 +1,103 @@
+import { Hono } from "hono";
+import { getUser } from "../middleware/auth";
+import { lookupFood } from "../lib/ai";
+import { prisma } from "../lib/db";
+import { log } from "../middleware/logger";
+
+const foods = new Hono();
+
+// Lookup food by name (DB cache first, AI fallback)
+foods.get("/lookup", async (c) => {
+  const q = c.req.query("q");
+  if (!q || q.trim().length === 0) {
+    return c.json({ error: "Query required" }, 400);
+  }
+
+  const food = await lookupFood(q.trim());
+  return c.json(food);
+});
+
+// Get user favorites
+foods.get("/favorites", async (c) => {
+  const user = getUser(c);
+
+  const favorites = await prisma.favorite.findMany({
+    where: { userId: user.id },
+    include: { food: true },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return c.json(favorites);
+});
+
+// Add to favorites
+foods.post("/favorites", async (c) => {
+  const user = getUser(c);
+  const { foodId } = await c.req.json();
+
+  const existing = await prisma.favorite.findUnique({
+    where: { userId_foodId: { userId: user.id, foodId } },
+  });
+
+  if (existing) {
+    return c.json({ error: "Already in favorites" }, 409);
+  }
+
+  const favorite = await prisma.favorite.create({
+    data: { userId: user.id, foodId },
+    include: { food: true },
+  });
+
+  log.info({ foodId }, "Added to favorites");
+  return c.json(favorite, 201);
+});
+
+// Remove from favorites
+foods.delete("/favorites/:id", async (c) => {
+  const user = getUser(c);
+  const id = c.req.param("id");
+
+  const favorite = await prisma.favorite.findFirst({
+    where: { id, userId: user.id },
+  });
+
+  if (!favorite) return c.json({ error: "Not found" }, 404);
+
+  await prisma.favorite.delete({ where: { id } });
+  log.info({ id }, "Removed from favorites");
+  return c.json({ success: true });
+});
+
+// Quick-log from favorite
+foods.post("/favorites/log", async (c) => {
+  const user = getUser(c);
+  const body = await c.req.json();
+  const { foodId, quantity, category } = body;
+
+  const food = await prisma.food.findUnique({ where: { id: foodId } });
+  if (!food) return c.json({ error: "Food not found" }, 404);
+
+  const multiplier = quantity / 100;
+  const meal = await prisma.meal.create({
+    data: {
+      userId: user.id,
+      category: category || null,
+      items: {
+        create: {
+          foodId: food.id,
+          quantity,
+          calories: food.caloriesPer100g * multiplier,
+          protein: food.proteinPer100g * multiplier,
+          carbs: food.carbsPer100g * multiplier,
+          fat: food.fatPer100g * multiplier,
+        },
+      },
+    },
+    include: { items: { include: { food: true } } },
+  });
+
+  log.info({ mealId: meal.id }, "Quick-logged from favorite");
+  return c.json(meal, 201);
+});
+
+export default foods;

--- a/apps/web/src/routes/favorites.module.css
+++ b/apps/web/src/routes/favorites.module.css
@@ -1,0 +1,37 @@
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 16px;
+  min-height: 100vh;
+  background: #f5f5f5;
+}
+
+.favItem {
+  flex-direction: column !important;
+  align-items: stretch !important;
+}
+
+.favHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.favActions {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.macros {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.quickLog {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 8px;
+}

--- a/apps/web/src/routes/favorites.tsx
+++ b/apps/web/src/routes/favorites.tsx
@@ -1,0 +1,174 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useState } from "react";
+import {
+  Button,
+  Card,
+  Typography,
+  List,
+  InputNumber,
+  Empty,
+  Popconfirm,
+  Select,
+  message,
+} from "antd";
+import {
+  ArrowLeftOutlined,
+  DeleteOutlined,
+  ThunderboltOutlined,
+  SearchOutlined,
+} from "@ant-design/icons";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import api from "@/lib/axios";
+import styles from "./favorites.module.css";
+
+const { Title, Text } = Typography;
+
+interface Food {
+  id: string;
+  name: string;
+  caloriesPer100g: number;
+  proteinPer100g: number;
+  carbsPer100g: number;
+  fatPer100g: number;
+}
+
+interface Favorite {
+  id: string;
+  foodId: string;
+  food: Food;
+}
+
+function FavoritesPage() {
+  const [quickLogState, setQuickLogState] = useState<Record<string, { qty: number; cat?: string }>>({});
+  const queryClient = useQueryClient();
+
+  const { data: favorites = [], isLoading } = useQuery<Favorite[]>({
+    queryKey: ["favorites"],
+    queryFn: () => api.get("/api/foods/favorites").then((r) => r.data),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/api/foods/favorites/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["favorites"] });
+      message.success("Removed from favorites");
+    },
+  });
+
+  const logMutation = useMutation({
+    mutationFn: (data: { foodId: string; quantity: number; category?: string }) =>
+      api.post("/api/foods/favorites/log", data),
+    onSuccess: () => {
+      message.success("Meal logged");
+      queryClient.invalidateQueries({ queryKey: ["meals"] });
+      queryClient.invalidateQueries({ queryKey: ["stats"] });
+    },
+  });
+
+  const handleQuickLog = (fav: Favorite) => {
+    const state = quickLogState[fav.id] || { qty: 100 };
+    logMutation.mutate({
+      foodId: fav.foodId,
+      quantity: state.qty,
+      category: state.cat,
+    });
+  };
+
+  const updateState = (favId: string, updates: Partial<{ qty: number; cat: string }>) => {
+    setQuickLogState((prev) => ({
+      ...prev,
+      [favId]: { ...({ qty: 100, ...prev[favId] }), ...updates },
+    }));
+  };
+
+  return (
+    <div className={styles.container}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+        <Link to="/">
+          <Button type="text" icon={<ArrowLeftOutlined />}>Back</Button>
+        </Link>
+        <Link to="/food-lookup">
+          <Button icon={<SearchOutlined />}>Lookup Food</Button>
+        </Link>
+      </div>
+      <Title level={3}>Favorites</Title>
+
+      {favorites.length === 0 && !isLoading ? (
+        <Card>
+          <Empty description="No favorites yet">
+            <Link to="/food-lookup">
+              <Button type="primary">Look up foods</Button>
+            </Link>
+          </Empty>
+        </Card>
+      ) : (
+        <List
+          loading={isLoading}
+          dataSource={favorites}
+          renderItem={(fav) => {
+            const f = fav.food;
+            const state = quickLogState[fav.id] || { qty: 100 };
+            return (
+              <List.Item className={styles.favItem}>
+                <div className={styles.favHeader}>
+                  <Text strong>{f.name}</Text>
+                  <div className={styles.favActions}>
+                    <Popconfirm
+                      title="Remove from favorites?"
+                      onConfirm={() => deleteMutation.mutate(fav.id)}
+                    >
+                      <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+                    </Popconfirm>
+                  </div>
+                </div>
+                <div className={styles.macros}>
+                  <Text type="secondary">{Math.round(f.caloriesPer100g)} cal/100g</Text>
+                  <Text type="secondary">P: {f.proteinPer100g}g</Text>
+                  <Text type="secondary">C: {f.carbsPer100g}g</Text>
+                  <Text type="secondary">F: {f.fatPer100g}g</Text>
+                </div>
+                <div className={styles.quickLog}>
+                  <InputNumber
+                    size="small"
+                    min={1}
+                    value={state.qty}
+                    onChange={(v) => updateState(fav.id, { qty: v || 100 })}
+                    addonAfter="g"
+                    style={{ width: 120 }}
+                  />
+                  <Select
+                    size="small"
+                    placeholder="Category"
+                    allowClear
+                    style={{ width: 110 }}
+                    value={state.cat}
+                    onChange={(v) => updateState(fav.id, { cat: v })}
+                    options={[
+                      { label: "Breakfast", value: "breakfast" },
+                      { label: "Lunch", value: "lunch" },
+                      { label: "Dinner", value: "dinner" },
+                      { label: "Snack", value: "snack" },
+                    ]}
+                  />
+                  <Button
+                    type="primary"
+                    size="small"
+                    icon={<ThunderboltOutlined />}
+                    onClick={() => handleQuickLog(fav)}
+                    loading={logMutation.isPending}
+                  >
+                    Log
+                  </Button>
+                </div>
+              </List.Item>
+            );
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/favorites")({
+  component: FavoritesPage,
+});

--- a/apps/web/src/routes/food-lookup.module.css
+++ b/apps/web/src/routes/food-lookup.module.css
@@ -1,0 +1,29 @@
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 16px;
+  min-height: 100vh;
+  background: #f5f5f5;
+}
+
+.searchRow {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.resultCard {
+  margin-bottom: 12px;
+}
+
+.resultHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.macros {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+}

--- a/apps/web/src/routes/food-lookup.tsx
+++ b/apps/web/src/routes/food-lookup.tsx
@@ -1,0 +1,107 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useState } from "react";
+import { Input, Button, Card, Typography, Tag, message, Spin } from "antd";
+import { SearchOutlined, HeartOutlined, HeartFilled, ArrowLeftOutlined } from "@ant-design/icons";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import api from "@/lib/axios";
+import styles from "./food-lookup.module.css";
+
+const { Title, Text } = Typography;
+
+interface FoodResult {
+  id: string;
+  name: string;
+  description: string | null;
+  caloriesPer100g: number;
+  proteinPer100g: number;
+  carbsPer100g: number;
+  fatPer100g: number;
+}
+
+function FoodLookupPage() {
+  const [query, setQuery] = useState("");
+  const [result, setResult] = useState<FoodResult | null>(null);
+  const [savedIds, setSavedIds] = useState<Set<string>>(new Set());
+  const queryClient = useQueryClient();
+
+  const lookupMutation = useMutation({
+    mutationFn: (q: string) =>
+      api.get(`/api/foods/lookup?q=${encodeURIComponent(q)}`).then((r) => r.data),
+    onSuccess: (data) => setResult(data),
+  });
+
+  const favMutation = useMutation({
+    mutationFn: (foodId: string) =>
+      api.post("/api/foods/favorites", { foodId }),
+    onSuccess: (_, foodId) => {
+      setSavedIds((prev) => new Set(prev).add(foodId));
+      queryClient.invalidateQueries({ queryKey: ["favorites"] });
+      message.success("Added to favorites");
+    },
+  });
+
+  const handleSearch = () => {
+    if (!query.trim()) return;
+    lookupMutation.mutate(query.trim());
+  };
+
+  return (
+    <div className={styles.container}>
+      <div style={{ marginBottom: 16 }}>
+        <Link to="/">
+          <Button type="text" icon={<ArrowLeftOutlined />}>Back</Button>
+        </Link>
+      </div>
+      <Title level={3}>Food Lookup</Title>
+
+      <div className={styles.searchRow}>
+        <Input
+          placeholder="Search for a food..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onPressEnter={handleSearch}
+          prefix={<SearchOutlined />}
+        />
+        <Button
+          type="primary"
+          onClick={handleSearch}
+          loading={lookupMutation.isPending}
+        >
+          Search
+        </Button>
+      </div>
+
+      {lookupMutation.isPending && <Spin style={{ display: "block", textAlign: "center" }} />}
+
+      {result && !lookupMutation.isPending && (
+        <Card className={styles.resultCard}>
+          <div className={styles.resultHeader}>
+            <div>
+              <Text strong style={{ fontSize: 16 }}>{result.name}</Text>
+              {result.description && (
+                <div><Text type="secondary">{result.description}</Text></div>
+              )}
+            </div>
+            <Button
+              type="text"
+              icon={savedIds.has(result.id) ? <HeartFilled style={{ color: "#ff4d4f" }} /> : <HeartOutlined />}
+              onClick={() => favMutation.mutate(result.id)}
+              disabled={savedIds.has(result.id)}
+            />
+          </div>
+          <Tag color="blue" style={{ marginTop: 8 }}>Per 100g</Tag>
+          <div className={styles.macros}>
+            <Text>{Math.round(result.caloriesPer100g)} cal</Text>
+            <Text type="secondary">P: {result.proteinPer100g}g</Text>
+            <Text type="secondary">C: {result.carbsPer100g}g</Text>
+            <Text type="secondary">F: {result.fatPer100g}g</Text>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/food-lookup")({
+  component: FoodLookupPage,
+});

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Button, Card, Typography, DatePicker } from "antd";
-import { PlusOutlined, LeftOutlined, RightOutlined, SettingOutlined } from "@ant-design/icons";
+import { PlusOutlined, LeftOutlined, RightOutlined, SettingOutlined, HeartOutlined, SearchOutlined } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import dayjs from "dayjs";
@@ -37,6 +37,12 @@ function DashboardPage() {
         <div className={styles.headerActions}>
           <Link to="/log">
             <Button type="primary" icon={<PlusOutlined />}>Log Meal</Button>
+          </Link>
+          <Link to="/food-lookup">
+            <Button icon={<SearchOutlined />} />
+          </Link>
+          <Link to="/favorites">
+            <Button icon={<HeartOutlined />} />
           </Link>
           <Link to="/settings">
             <Button icon={<SettingOutlined />} />


### PR DESCRIPTION
## Summary
- Food lookup page: search by name, DB cache first then GPT-4o fallback, save to favorites
- Favorites page: list saved foods, quick-log with quantity/category selector
- API: GET /foods/lookup, CRUD /foods/favorites, POST /foods/favorites/log
- Dashboard header links to lookup + favorites

Closes #11, closes #12

## Test plan
- [ ] Search for a food, verify per-100g data returned
- [ ] Save to favorites, verify appears on favorites page
- [ ] Quick-log from favorite with custom quantity
- [ ] Delete a favorite
- [ ] Search cached food returns instantly (no AI call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)