### PR TITLE
feat: settings page + mobile-first responsive (#13, #14)

### DIFF
--- a/apps/web/src/components/dashboard/EditMealModal.module.css
+++ b/apps/web/src/components/dashboard/EditMealModal.module.css
@@ -12,3 +12,18 @@
 .row .number {
   flex: 1;
 }
+
+@media (max-width: 480px) {
+  .row {
+    flex-wrap: wrap;
+  }
+
+  .row .name {
+    flex: 1 1 100%;
+  }
+
+  .row .number {
+    flex: 1 1 calc(33% - 6px);
+    min-width: 0;
+  }
+}

--- a/apps/web/src/global.css
+++ b/apps/web/src/global.css
@@ -1,0 +1,56 @@
+/* Global resets and mobile-first responsive */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Ensure minimum touch target size */
+button,
+.ant-btn,
+.ant-select-selector,
+.ant-input,
+.ant-input-number {
+  min-height: 44px;
+}
+
+.ant-btn-sm {
+  min-height: 32px;
+}
+
+/* Prevent zoom on iOS input focus */
+input,
+select,
+textarea {
+  font-size: 16px !important;
+}
+
+/* Mobile-friendly modal */
+@media (max-width: 480px) {
+  .ant-modal {
+    max-width: calc(100vw - 32px) !important;
+    margin: 16px auto !important;
+  }
+
+  .ant-modal .ant-modal-body {
+    overflow-x: auto;
+  }
+
+  /* Stacked edit modal rows on mobile */
+  .ant-modal .ant-input-number {
+    min-width: 60px;
+  }
+}
+
+/* Safe area insets for notched phones */
+#root {
+  padding-bottom: env(safe-area-inset-bottom);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,4 @@
+import "./global.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";

--- a/apps/web/src/routes/favorites.module.css
+++ b/apps/web/src/routes/favorites.module.css
@@ -34,4 +34,5 @@
   gap: 8px;
   align-items: center;
   margin-top: 8px;
+  flex-wrap: wrap;
 }

--- a/apps/web/src/routes/index.module.css
+++ b/apps/web/src/routes/index.module.css
@@ -30,3 +30,19 @@
 .section {
   margin-bottom: 16px;
 }
+
+@media (max-width: 480px) {
+  .container {
+    padding: 12px;
+  }
+
+  .header {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .headerActions {
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+}

--- a/apps/web/src/routes/settings.module.css
+++ b/apps/web/src/routes/settings.module.css
@@ -1,0 +1,24 @@
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 16px;
+  min-height: 100vh;
+  background: #f5f5f5;
+}
+
+.form {
+  margin-top: 16px;
+}
+
+.targets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.targetItem {
+  text-align: center;
+  flex: 1;
+  min-width: 80px;
+}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,0 +1,190 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+  Form,
+  InputNumber,
+  Select,
+  Button,
+  Card,
+  Typography,
+  Radio,
+  message,
+  Spin,
+} from "antd";
+import { ArrowLeftOutlined } from "@ant-design/icons";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import api from "@/lib/axios";
+import styles from "./settings.module.css";
+
+const { Title, Text } = Typography;
+
+const activityOptions = [
+  { value: "sedentary", label: "Sedentary (little/no exercise)" },
+  { value: "light", label: "Light (1-3 days/week)" },
+  { value: "moderate", label: "Moderate (3-5 days/week)" },
+  { value: "active", label: "Active (6-7 days/week)" },
+  { value: "very_active", label: "Very Active (intense daily)" },
+];
+
+const goalOptions = [
+  { value: "lose", label: "Lose weight" },
+  { value: "maintain", label: "Maintain weight" },
+  { value: "gain", label: "Gain weight" },
+];
+
+function SettingsPage() {
+  const [form] = Form.useForm();
+  const queryClient = useQueryClient();
+  const unitPreference = Form.useWatch("unitPreference", form);
+
+  const { data: profile, isPending } = useQuery({
+    queryKey: ["profile"],
+    queryFn: () => api.get("/api/profile").then((r) => r.data),
+  });
+
+  useEffect(() => {
+    if (profile) {
+      const unit = profile.unitPreference || "metric";
+      let weight = profile.weight;
+      let height = profile.height;
+
+      if (unit === "imperial" && weight && height) {
+        weight = Math.round(weight / 0.453592 * 10) / 10;
+        height = Math.round(height / 2.54 * 10) / 10;
+      }
+
+      form.setFieldsValue({
+        age: profile.age,
+        gender: profile.gender,
+        weight,
+        height,
+        activityLevel: profile.activityLevel,
+        goal: profile.goal,
+        unitPreference: unit,
+      });
+    }
+  }, [profile, form]);
+
+  const onFinish = async (values: Record<string, unknown>) => {
+    let weight = values.weight as number;
+    let height = values.height as number;
+
+    if (values.unitPreference === "imperial") {
+      weight = weight * 0.453592;
+      height = height * 2.54;
+    }
+
+    await api.put("/api/profile", {
+      age: values.age,
+      gender: values.gender,
+      weight: Math.round(weight * 10) / 10,
+      height: Math.round(height * 10) / 10,
+      activityLevel: values.activityLevel,
+      goal: values.goal,
+      unitPreference: values.unitPreference,
+    });
+
+    queryClient.invalidateQueries({ queryKey: ["profile"] });
+    queryClient.invalidateQueries({ queryKey: ["stats"] });
+    message.success("Settings saved!");
+  };
+
+  if (isPending) return <Spin style={{ display: "block", margin: "48px auto" }} />;
+
+  return (
+    <div className={styles.container}>
+      <div style={{ marginBottom: 16 }}>
+        <Link to="/">
+          <Button type="text" icon={<ArrowLeftOutlined />}>Back</Button>
+        </Link>
+      </div>
+
+      <Card>
+        <Title level={3}>Settings</Title>
+
+        {profile?.calorieTarget && (
+          <div style={{ marginBottom: 16 }}>
+            <Text type="secondary">Current targets</Text>
+            <div className={styles.targets}>
+              <div className={styles.targetItem}>
+                <div><Text strong>{Math.round(profile.calorieTarget)}</Text></div>
+                <Text type="secondary">cal</Text>
+              </div>
+              <div className={styles.targetItem}>
+                <div><Text strong>{Math.round(profile.proteinTarget)}g</Text></div>
+                <Text type="secondary">protein</Text>
+              </div>
+              <div className={styles.targetItem}>
+                <div><Text strong>{Math.round(profile.carbsTarget)}g</Text></div>
+                <Text type="secondary">carbs</Text>
+              </div>
+              <div className={styles.targetItem}>
+                <div><Text strong>{Math.round(profile.fatTarget)}g</Text></div>
+                <Text type="secondary">fat</Text>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={onFinish}
+          className={styles.form}
+        >
+          <Form.Item name="unitPreference" label="Units">
+            <Radio.Group>
+              <Radio.Button value="metric">Metric</Radio.Button>
+              <Radio.Button value="imperial">Imperial</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+
+          <Form.Item name="gender" label="Gender" rules={[{ required: true }]}>
+            <Radio.Group>
+              <Radio.Button value="male">Male</Radio.Button>
+              <Radio.Button value="female">Female</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+
+          <Form.Item name="age" label="Age" rules={[{ required: true }]}>
+            <InputNumber min={1} max={150} style={{ width: "100%" }} />
+          </Form.Item>
+
+          <Form.Item
+            name="weight"
+            label={unitPreference === "imperial" ? "Weight (lbs)" : "Weight (kg)"}
+            rules={[{ required: true }]}
+          >
+            <InputNumber min={1} step={0.1} style={{ width: "100%" }} />
+          </Form.Item>
+
+          <Form.Item
+            name="height"
+            label={unitPreference === "imperial" ? "Height (inches)" : "Height (cm)"}
+            rules={[{ required: true }]}
+          >
+            <InputNumber min={1} step={0.1} style={{ width: "100%" }} />
+          </Form.Item>
+
+          <Form.Item name="activityLevel" label="Activity Level" rules={[{ required: true }]}>
+            <Select options={activityOptions} />
+          </Form.Item>
+
+          <Form.Item name="goal" label="Goal" rules={[{ required: true }]}>
+            <Select options={goalOptions} />
+          </Form.Item>
+
+          <Form.Item>
+            <Button type="primary" htmlType="submit" size="large" block>
+              Save & Recalculate
+            </Button>
+          </Form.Item>
+        </Form>
+      </Card>
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/settings")({
+  component: SettingsPage,
+});


### PR DESCRIPTION
## Summary
- Settings page with pre-filled profile form, unit toggle, targets display
- PUT /profile recalculates Mifflin-St Jeor targets on save
- Global CSS: 44px min touch targets, iOS zoom prevention, safe area insets
- Responsive tweaks: edit modal rows wrap, header wraps, quick-log wraps on mobile
- Mobile modal width constraint

Closes #13, closes #14

## Test plan
- [ ] Settings page loads with current profile data
- [ ] Change a field, save, verify targets recalculated
- [ ] Toggle metric/imperial, verify conversion
- [ ] Test on 375px viewport — all pages usable
- [ ] Verify touch targets >= 44px on mobile
- [ ] Edit meal modal usable on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)